### PR TITLE
fix #20: rename opam package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           path: ~/repo
       - restore_cache:
           keys:
-            - v3-native-dependencies-<< parameters.ocaml-version >>-<< parameters.base-version >>-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
+            - v3-native-dependencies-<< parameters.ocaml-version >>-<< parameters.base-version >>-{{ .Branch }}-{{ checksum "tablecloth-base.opam" }}
             - v3-native-dependencies-<< parameters.ocaml-version >>-<< parameters.base-version >>-{{ .Branch }}-
             - v3-native-dependencies-<< parameters.ocaml-version >>-<< parameters.base-version >>-
       # m4 is a system dependency required by conf-m4 -> ocamlfind -> fmt -> alcotest
@@ -26,7 +26,7 @@ jobs:
       - run: make test
       - run: make integration-test
       - save_cache:
-          key: v3-native-dependencies-<< parameters.ocaml-version >>-<< parameters.base-version >>-{{ .Branch }}-{{ checksum "tablecloth-native.opam" }}
+          key: v3-native-dependencies-<< parameters.ocaml-version >>-<< parameters.base-version >>-{{ .Branch }}-{{ checksum "tablecloth-base.opam" }}
           paths:
             - ~/.opam
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .vscode
 _build
 /lib
-/tablecloth-native.install
+/tablecloth-base.install
 /integration-test/native/_build
 
 esy.lock

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 TC_OCAMLFORMAT_VERSION := 0.20.1
 
 build:
-	@printf "\n\e[31mBuilding tablecloth-native ...\e[0m\n"
+	@printf "\n\e[31mBuilding tablecloth-base ...\e[0m\n"
 	opam config exec -- dune build
 	@printf "\n\e[31mBuilt!\e[0m\n"
 
@@ -25,7 +25,7 @@ watch-test:
 
 .PHONY: test
 test:
-	@printf "\n\e[31mRunning tablecloth-native tests ...\e[0m\n"
+	@printf "\n\e[31mRunning tablecloth-base tests ...\e[0m\n"
 	opam config exec -- dune runtest -f
 	@printf "\n\e[31mTested!\e[0m\n"
 

--- a/deploying.md
+++ b/deploying.md
@@ -1,7 +1,7 @@
 To deploy to opam
 
-- update /tablecloth-native.opam to version x.y.z
+- update /tablecloth-base.opam to version x.y.z
 - git tag -f x.y.z
 - git push origin x.y.z
-- opam-publish tablecloth-native -v x.y.z https://github.com/darklang/tablecloth/archive/x.y.z.tar.gz
+- opam-publish tablecloth-base -v x.y.z https://github.com/darklang/tablecloth/archive/x.y.z.tar.gz
 - make the pull request work

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -44,6 +44,6 @@ https://dune.readthedocs.io/en/stable/concepts.html#ocaml-flags
 ```
 (library
  (name example-library)
- (libraries tablecloth-native)
+ (libraries tablecloth-base)
  (flags (:open Tablecloth)))
  ```

--- a/integration-test/dune
+++ b/integration-test/dune
@@ -2,6 +2,6 @@
  (name main)
  (flags
   (-warn-error +A))
- (libraries tablecloth-native))
+ (libraries tablecloth-base))
 
 (dirs :standard \ node_modules)

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name tablecloth)
- (public_name tablecloth-native)
+ (public_name tablecloth-base)
  (libraries base str))

--- a/tablecloth-base.opam
+++ b/tablecloth-base.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "tablecloth-native"
+name: "tablecloth-base"
 version: "0.0.8"
 synopsis: "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript"
 description: """
@@ -8,11 +8,12 @@ Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml 
 maintainer: "Paul Biggar <paul@darklang.com>"
 authors: [
   "Paul Biggar <paul@darklang.com>"
-  "Dean Merchant <deanmerchant@gmail.com"
+  "Dean Merchant <deanmerchant@gmail.com>"
+  "Pomin Wu <pomin.wu@proton.me>"
 ]
 license: "MIT with some exceptions"
-homepage: "https://github.com/darklang/tablecloth"
-bug-reports: "https://github.com/darklang/tablecloth/issues"
-dev-repo: "git://github.com/darklang/tablecloth"
+homepage: "hhttps://github.com/darklang/tablecloth-ocaml-base"
+bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
+dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
 depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {build} "base" { >= "v0.12.0" & < "v0.15.0" } ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
- Changed OPAM package name from tablecloth-native to tablecloth-base.
- Changed GitHub repository name from tablecloth-native to tablecloth-ocaml-base.