### PR TITLE
Fix opam typo

### DIFF
--- a/tablecloth-base.opam
+++ b/tablecloth-base.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "tablecloth-base"
-version: "0.0.8"
+version: "0.0.9"
 synopsis: "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript"
 description: """
 Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.
@@ -11,10 +11,10 @@ authors: [
   "Dean Merchant <deanmerchant@gmail.com>"
   "Pomin Wu <pomin.wu@proton.me>"
 ]
-license: "MIT with some exceptions"
+license: "MIT"
 homepage: "https://github.com/darklang/tablecloth-ocaml-base"
 bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
 dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
-depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {build} "base" { >= "v0.12.0" & < "v0.15.0" } ]
+depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {>= "2.4" } "base" { >= "v0.12.0" & < "v0.15.0" } ]
 build: ["dune" "build" "-p" name "-j" jobs]
 conflicts: [ "tablecloth-native" {!= "transition"} ]

--- a/tablecloth-base.opam
+++ b/tablecloth-base.opam
@@ -12,7 +12,7 @@ authors: [
   "Pomin Wu <pomin.wu@proton.me>"
 ]
 license: "MIT with some exceptions"
-homepage: "hhttps://github.com/darklang/tablecloth-ocaml-base"
+homepage: "https://github.com/darklang/tablecloth-ocaml-base"
 bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
 dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
 depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {build} "base" { >= "v0.12.0" & < "v0.15.0" } ]


### PR DESCRIPTION
- License change comes from https://github.com/darklang/tablecloth/commit/08d4d51e98db9f75869d2cda0f12c13b6316329f which wasn't picked up when we split repositories.
- Also bumped version because this version contains updates that were not in the 0.0.8 release.