### PR TITLE
Upgrade to OCaml 5 and Base 0.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,16 @@ workflows:
             parameters:
               base-version: ["v0.13.2"]
               ocaml-version: ["4.08", "4.09", "4.10", "4.11"]
-      # Base 0.14.1 requires ocaml >= 4.08
-      # Currently broken as due to Either definition
+      # Base 0.14 requires ocaml >= 4.08
       - build-and-test:
           matrix:
             parameters:
               base-version: ["v0.14.3"]
               ocaml-version: ["4.08", "4.09", "4.10", "4.11", "4.12", "4.13", "4.14"]
+      # Base 0.15 requires ocaml >= 4.10
+      - build-and-test:
+          matrix:
+            parameters:
+              base-version: ["v0.15.1"]
+              ocaml-version: ["4.10", "4.11", "4.12", "4.13", "4.14"]
       - source-code-formatting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,33 +60,21 @@ workflows:
       # --------------------
       # OCaml version matrix
       # --------------------
-      # We currently only support native OCaml > 4.08, as we use the Fun module
-      # which was only added in 4.08
-      # Base 0.9.4 requires ocaml < 4.07, which we don't support
-      # Base 0.10.0 requires ocaml < 4.07, which we don't support
-      # Base 0.11.1 requires ocaml < 4.07, which we don't support
-      # Base 0.12 requires ocaml < 4.10
-      - build-and-test:
-          matrix:
-            parameters:
-              base-version: ["v0.12.2"]
-              ocaml-version: ["4.08", "4.09"]
-      # Base 0.13.2 requires ocaml < 4.12
-      - build-and-test:
-          matrix:
-            parameters:
-              base-version: ["v0.13.2"]
-              ocaml-version: ["4.08", "4.09", "4.10", "4.11"]
-      # Base 0.14 requires ocaml >= 4.08
-      - build-and-test:
-          matrix:
-            parameters:
-              base-version: ["v0.14.3"]
-              ocaml-version: ["4.08", "4.09", "4.10", "4.11", "4.12", "4.13", "4.14"]
+      # We currently only support Base >= 0.15 and OCaml >= 4.10
       # Base 0.15 requires ocaml >= 4.10
       - build-and-test:
           matrix:
             parameters:
               base-version: ["v0.15.1"]
               ocaml-version: ["4.10", "4.11", "4.12", "4.13", "4.14"]
+      - build-and-test:
+          matrix:
+            parameters:
+              base-version: ["v0.16.3"]
+              ocaml-version: ["4.14", "5.0", "5.1", "5.2"]
+      - build-and-test:
+          matrix:
+            parameters:
+              base-version: ["v0.17.1"]
+              ocaml-version: ["5.1", "5.2"]
       - source-code-formatting

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deps:
 	@printf "\n\e[31mInstalling native dependencies ...\e[0m\n"
 	opam update
 	opam switch set ${TC_NATIVE_OCAML_SWITCH}
-	opam install alcotest.1.4.0 base.${TC_BASE_VERSION} dune.3.16.0 junit.2.0.2 junit_alcotest.2.0.2 odoc.2.1.1 -y
+	opam install alcotest.1.4.0 base.${TC_BASE_VERSION} dune.3.16.0 junit.2.0.2 junit_alcotest.2.0.2 odoc.2.4.2 -y
 	@printf "\n\e[31mInstalled!\e[0m\n"
 
 deps-format:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifndef TC_NATIVE_OCAML_SWITCH
 endif
 
 ifndef TC_BASE_VERSION
-	TC_BASE_VERSION := v0.14.3
+	TC_BASE_VERSION := v0.15.1
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deps:
 	@printf "\n\e[31mInstalling native dependencies ...\e[0m\n"
 	opam update
 	opam switch set ${TC_NATIVE_OCAML_SWITCH}
-	opam install alcotest.1.4.0 base.${TC_BASE_VERSION} dune.2.9.1 junit.2.0.2 junit_alcotest.2.0.2 odoc.2.1.1 -y
+	opam install alcotest.1.4.0 base.${TC_BASE_VERSION} dune.3.16.0 junit.2.0.2 junit_alcotest.2.0.2 odoc.2.1.1 -y
 	@printf "\n\e[31mInstalled!\e[0m\n"
 
 deps-format:

--- a/README.md
+++ b/README.md
@@ -46,18 +46,17 @@ let () =
 
 ## Supported versions
 
-Tablecloth for native OCaml supports OCaml 4.08-4.14 and Base
-v0.12.2/v0.13.2/v0.14.3. We are open to supporting other versions:
+Tablecloth for native OCaml supports OCaml 4.10-4.14 with Base v0.15.1, and OCaml 4.14 and above with Base v0.16.3/v0.17.1.  We are open to supporting other versions:
 
 - OCaml 4.06 and 4.07 require small tweaks to our build system
-- Base v0.9, v0.10, and v0.11 require small code changes
+- Base v0.9 to v0.14 require small code changes
 
 ### Development
 
 When developing Tablecloth, you can test it against different versions of
 OCaml (native) and Base, using the following commands:
 
-- `TC_BASE_VERSION=v0.14.0 TC_NATIVE_OCAML_SWITCH=4.11.0 make deps`
+- `TC_BASE_VERSION=v0.16.3 TC_NATIVE_OCAML_SWITCH=5.2.0 make deps`
 
 ## Contributions
 

--- a/src/Internal.ml
+++ b/src/Internal.ml
@@ -1,5 +1,5 @@
 module Comparator = TableclothComparator
 
 let to_base_comparator (comparator : ('a, 'id) TableclothComparator.s) :
-    ('a, 'id) Base.Map.comparator =
+    ('a, 'id) Base.Comparator.Module.t =
   Obj.magic comparator

--- a/tablecloth-base.opam
+++ b/tablecloth-base.opam
@@ -15,6 +15,6 @@ license: "MIT"
 homepage: "https://github.com/darklang/tablecloth-ocaml-base"
 bug-reports: "https://github.com/darklang/tablecloth-ocaml-base/issues"
 dev-repo: "git://github.com/darklang/tablecloth-ocaml-base"
-depends: [ "ocaml" {>= "4.08" < "4.15" } "dune" {>= "2.4" } "base" { >= "v0.12.0" & < "v0.15.0" } ]
+depends: [ "ocaml" {>= "4.10" } "dune" {>= "2.4" } "base" { >= "v0.15.0" } ]
 build: ["dune" "build" "-p" name "-j" jobs]
 conflicts: [ "tablecloth-native" {!= "transition"} ]

--- a/tablecloth-base.opam
+++ b/tablecloth-base.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "tablecloth-base"
-version: "0.0.9"
+version: "0.0.10"
 synopsis: "Native OCaml library implementing Tablecloth, a cross-platform standard library for OCaml and Rescript"
 description: """
 Tablecloth is an ergonomic, cross-platform, standard library for use with OCaml and Rescript. It provides an easy-to-use, comprehensive and performant standard library, that has the same API on in OCaml and Rescript.


### PR DESCRIPTION
- The use of Base comparators was changed since v0.15.1 in December 2021.
- This breaks support for Base < v0.15, and therefore for OCaml < 4.10.
- The good part is that we can now support OCaml 5 with Base >= 0.16.